### PR TITLE
[fix] some urls will be misjudged to phone

### DIFF
--- a/lib/src/utils/regex.dart
+++ b/lib/src/utils/regex.dart
@@ -59,13 +59,13 @@ LinkType getMatchedType(String match) {
   late LinkType type;
   if (RegExp(emailRegExp).hasMatch(match)) {
     type = LinkType.email;
-  } else if (RegExp(phoneRegExp).hasMatch(match)) {
+  } else if (RegExp(urlRegExp).hasMatch(match)) {
+    type = LinkType.url;
+  }else if (RegExp(phoneRegExp).hasMatch(match)) {
     type = LinkType.phone;
   } else if (RegExp(userTagRegExp).hasMatch(match)) {
     type = LinkType.userTag;
-  } else if (RegExp(urlRegExp).hasMatch(match)) {
-    type = LinkType.url;
-  } else if (RegExp(hashtagRegExp).hasMatch(match)) {
+  }  else if (RegExp(hashtagRegExp).hasMatch(match)) {
     type = LinkType.hashTag;
   }
   return type;


### PR DESCRIPTION
Give an example as "https://www.zhihu.com/question/648850626?utm_campaign=shareopn&utm_content=group2_questions&utm_medium=social&utm_psn=1753366003193782272&utm_source=wechat_session&utm_id=0",Obviously this is a link in web page format, but it also conforms to our regular rules for determining the format of mobile phone numbers. Obviously, all links in web page format will definitely not be judged as mobile phone numbers, so I think we should increase the priority of judging web page format in if.